### PR TITLE
feat: create borderWidth Attribute for W.Message

### DIFF
--- a/example/src/Chapters/Information/Message.elm
+++ b/example/src/Chapters/Information/Message.elm
@@ -18,6 +18,8 @@ chapter_ =
              , ( [ W.Message.warning ], "Warning" )
              , ( [ W.Message.danger ], "Danger" )
              , ( [ W.Message.color "purple" ], "Custom" )
+             , ( [ W.Message.noBorder  ], "No border" )
+             , ( [ W.Message.borderWidth 12 ], "Increased border" )
              ]
                 |> List.map
                     (\( attrs, label ) ->

--- a/example/src/Chapters/Information/Message.elm
+++ b/example/src/Chapters/Information/Message.elm
@@ -18,7 +18,7 @@ chapter_ =
              , ( [ W.Message.warning ], "Warning" )
              , ( [ W.Message.danger ], "Danger" )
              , ( [ W.Message.color "purple" ], "Custom" )
-             , ( [ W.Message.noBorder  ], "No border" )
+             , ( [ W.Message.borderWidth 0  ], "No border" )
              , ( [ W.Message.borderWidth 12 ], "Increased border" )
              ]
                 |> List.map

--- a/src/W/Message.elm
+++ b/src/W/Message.elm
@@ -1,7 +1,7 @@
 module W.Message exposing
     ( view
     , icon, footer
-    , primary, secondary, success, warning, danger, color, noBorder
+    , primary, secondary, success, warning, danger, color
     , href, onClick
     , htmlAttrs, noAttr, Attribute
     , borderWidth
@@ -57,7 +57,6 @@ type alias Attributes msg =
     , href : Maybe String
     , onClick : Maybe msg
     , borderWidth : Int
-    , noBorder : Bool
     }
 
 
@@ -75,7 +74,6 @@ defaultAttrs =
     , href = Nothing
     , onClick = Nothing
     , borderWidth = 6
-    , noBorder = False
     }
 
 
@@ -173,14 +171,6 @@ borderWidth v =
             { attrs | borderWidth = v }
 
 
-{-| -}
-noBorder : Attribute msg
-noBorder =
-    Attribute <|
-        \attrs ->
-            { attrs | noBorder = True }
-
-
 
 -- Main
 
@@ -205,12 +195,7 @@ view attrs_ children_ =
                    , HA.class "ew-py-2 ew-px-4 ew-pr-6"
                    , HA.class "ew-bg-base-bg ew-rounded"
                    , HA.style "border-left-width"
-                        (if attrs.noBorder then
-                            ""
-
-                         else
-                            String.fromInt attrs.borderWidth ++ "px"
-                        )
+                        (String.fromInt attrs.borderWidth ++ "px")
                    , HA.class
                         "ew-border-solid ew-border-current"
                    , HA.style "color" attrs.color

--- a/src/W/Message.elm
+++ b/src/W/Message.elm
@@ -1,10 +1,10 @@
 module W.Message exposing
     ( view
     , icon, footer
-    , primary, secondary, success, warning, danger, color
+    , primary, secondary, success, warning, danger, color, noBorder
     , href, onClick
     , htmlAttrs, noAttr, Attribute
-    , borderWidth, noBorder
+    , borderWidth
     )
 
 {-|
@@ -19,7 +19,7 @@ module W.Message exposing
 
 # Styles
 
-@docs primary, secondary, success, warning, danger, color
+@docs primary, secondary, success, warning, danger, color, noBorder, customBorder
 
 
 # Actions
@@ -165,6 +165,7 @@ danger =
             { attrs | color = Theme.dangerForeground }
 
 
+{-| -}
 borderWidth : Int -> Attribute msg
 borderWidth v =
     Attribute <|
@@ -172,6 +173,7 @@ borderWidth v =
             { attrs | borderWidth = v }
 
 
+{-| -}
 noBorder : Attribute msg
 noBorder =
     Attribute <|
@@ -217,20 +219,6 @@ view attrs_ children_ =
                    , HA.class "before:ew-rounded-r before:ew-bg-current before:ew-opacity-[0.07]"
                    ]
 
-        -- baseAttrs : List (H.Attribute msg)
-        -- baseAttrs =
-        --     attrs.htmlAttributes
-        --         ++ [ HA.class "ew-m-0 ew-box-border ew-relative"
-        --            , HA.class "ew-flex ew-gap-4 ew-w-full"
-        --            , HA.class "ew-font-text ew-text-base ew-font-medium"
-        --            , HA.class "ew-py-2 ew-px-4 ew-pr-6"
-        --            , HA.class "ew-bg-base-bg ew-rounded"
-        --            , HA.class "ew-border-l-[6px] ew-border-0 ew-border-solid ew-border-current"
-        --            , HA.style "color" attrs.color
-        --            , HA.class "before:ew-block before:ew-content-['']"
-        --            , HA.class "before:ew-absolute before:ew-inset-0 ew-z-0"
-        --            , HA.class "before:ew-rounded-r before:ew-bg-current before:ew-opacity-[0.07]"
-        --            ]
         children : List (H.Html msg)
         children =
             [ WH.maybeHtml (\i -> H.div [] i) attrs.icon

--- a/src/W/Message.elm
+++ b/src/W/Message.elm
@@ -4,6 +4,7 @@ module W.Message exposing
     , primary, secondary, success, warning, danger, color
     , href, onClick
     , htmlAttrs, noAttr, Attribute
+    , borderWidth, noBorder
     )
 
 {-|
@@ -55,6 +56,8 @@ type alias Attributes msg =
     , color : String
     , href : Maybe String
     , onClick : Maybe msg
+    , borderWidth : Int
+    , noBorder : Bool
     }
 
 
@@ -71,6 +74,8 @@ defaultAttrs =
     , color = Theme.neutralForeground
     , href = Nothing
     , onClick = Nothing
+    , borderWidth = 6
+    , noBorder = False
     }
 
 
@@ -160,6 +165,20 @@ danger =
             { attrs | color = Theme.dangerForeground }
 
 
+borderWidth : Int -> Attribute msg
+borderWidth v =
+    Attribute <|
+        \attrs ->
+            { attrs | borderWidth = v }
+
+
+noBorder : Attribute msg
+noBorder =
+    Attribute <|
+        \attrs ->
+            { attrs | noBorder = True }
+
+
 
 -- Main
 
@@ -183,7 +202,15 @@ view attrs_ children_ =
                    , HA.class "ew-font-text ew-text-base ew-font-medium"
                    , HA.class "ew-py-2 ew-px-4 ew-pr-6"
                    , HA.class "ew-bg-base-bg ew-rounded"
-                   , HA.class "ew-border-l-[6px] ew-border-0 ew-border-solid ew-border-current"
+                   , HA.class
+                        (if attrs.noBorder then
+                            ""
+
+                         else
+                            "ew-border-l-["
+                                ++ String.fromInt attrs.borderWidth
+                                ++ "px] ew-border-0 ew-border-solid ew-border-current"
+                        )
                    , HA.style "color" attrs.color
                    , HA.class "before:ew-block before:ew-content-['']"
                    , HA.class "before:ew-absolute before:ew-inset-0 ew-z-0"

--- a/src/W/Message.elm
+++ b/src/W/Message.elm
@@ -202,21 +202,35 @@ view attrs_ children_ =
                    , HA.class "ew-font-text ew-text-base ew-font-medium"
                    , HA.class "ew-py-2 ew-px-4 ew-pr-6"
                    , HA.class "ew-bg-base-bg ew-rounded"
-                   , HA.class
+                   , HA.style "border-left-width"
                         (if attrs.noBorder then
                             ""
 
                          else
-                            "ew-border-l-["
-                                ++ String.fromInt attrs.borderWidth
-                                ++ "px] ew-border-0 ew-border-solid ew-border-current"
+                            String.fromInt attrs.borderWidth ++ "px"
                         )
+                   , HA.class
+                        "ew-border-solid ew-border-current"
                    , HA.style "color" attrs.color
                    , HA.class "before:ew-block before:ew-content-['']"
                    , HA.class "before:ew-absolute before:ew-inset-0 ew-z-0"
                    , HA.class "before:ew-rounded-r before:ew-bg-current before:ew-opacity-[0.07]"
                    ]
 
+        -- baseAttrs : List (H.Attribute msg)
+        -- baseAttrs =
+        --     attrs.htmlAttributes
+        --         ++ [ HA.class "ew-m-0 ew-box-border ew-relative"
+        --            , HA.class "ew-flex ew-gap-4 ew-w-full"
+        --            , HA.class "ew-font-text ew-text-base ew-font-medium"
+        --            , HA.class "ew-py-2 ew-px-4 ew-pr-6"
+        --            , HA.class "ew-bg-base-bg ew-rounded"
+        --            , HA.class "ew-border-l-[6px] ew-border-0 ew-border-solid ew-border-current"
+        --            , HA.style "color" attrs.color
+        --            , HA.class "before:ew-block before:ew-content-['']"
+        --            , HA.class "before:ew-absolute before:ew-inset-0 ew-z-0"
+        --            , HA.class "before:ew-rounded-r before:ew-bg-current before:ew-opacity-[0.07]"
+        --            ]
         children : List (H.Html msg)
         children =
             [ WH.maybeHtml (\i -> H.div [] i) attrs.icon

--- a/src/W/Message.elm
+++ b/src/W/Message.elm
@@ -1,10 +1,9 @@
 module W.Message exposing
     ( view
     , icon, footer
-    , primary, secondary, success, warning, danger, color
+    , primary, secondary, success, warning, danger, color, borderWidth
     , href, onClick
     , htmlAttrs, noAttr, Attribute
-    , borderWidth
     )
 
 {-|
@@ -19,7 +18,7 @@ module W.Message exposing
 
 # Styles
 
-@docs primary, secondary, success, warning, danger, color, noBorder, customBorder
+@docs primary, secondary, success, warning, danger, color, borderWidth
 
 
 # Actions


### PR DESCRIPTION
### No Border 
<img width="778" alt="Screen Shot 2024-07-24 at 13 21 12" src="https://github.com/user-attachments/assets/7633bec3-5881-4f14-975b-68e2d1888953">


### Custom Border 
<img width="804" alt="Screen Shot 2024-07-24 at 13 21 26" src="https://github.com/user-attachments/assets/9c965360-6fd2-4a52-8eda-b2e8f4c445d6">



## Before
W.Message had no options to customize it's border. 

## Now
Now we can customize border Attributes:
- BorderWidth (Defines border width in pixel size). Set it as 0 for no border.